### PR TITLE
[Feat] 교육 상세 조회 구현

### DIFF
--- a/src/main/java/com/mumu/mumu/controller/EduListController.java
+++ b/src/main/java/com/mumu/mumu/controller/EduListController.java
@@ -4,10 +4,7 @@ import com.mumu.mumu.domain.Edu;
 import com.mumu.mumu.dto.EduListResponseDto;
 import com.mumu.mumu.service.EduListService;
 import lombok.RequiredArgsConstructor;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 import java.util.stream.Collectors;
@@ -30,5 +27,10 @@ public class EduListController {
         return eduLists.stream()
                 .map(EduListResponseDto::new)  // EduList -> EduListResponseDto로 변환
                 .collect(Collectors.toList());
+    }
+
+    @GetMapping("/{eduId}")
+    public EduListResponseDto getEduById(@PathVariable Long eduId) {
+        return eduListService.getEduById(eduId);
     }
 }

--- a/src/main/java/com/mumu/mumu/controller/EduListController.java
+++ b/src/main/java/com/mumu/mumu/controller/EduListController.java
@@ -1,6 +1,7 @@
 package com.mumu.mumu.controller;
 
 import com.mumu.mumu.domain.Edu;
+import com.mumu.mumu.dto.EduDetailResponseDto;
 import com.mumu.mumu.dto.EduListResponseDto;
 import com.mumu.mumu.service.EduListService;
 import lombok.RequiredArgsConstructor;
@@ -30,7 +31,7 @@ public class EduListController {
     }
 
     @GetMapping("/{eduId}")
-    public EduListResponseDto getEduById(@PathVariable Long eduId) {
+    public EduDetailResponseDto getEduById(@PathVariable Long eduId) {
         return eduListService.getEduById(eduId);
     }
 }

--- a/src/main/java/com/mumu/mumu/domain/Edu.java
+++ b/src/main/java/com/mumu/mumu/domain/Edu.java
@@ -71,6 +71,18 @@ public class Edu {
     @Column(name = "edu_teacher")
     private String eduTeacher;
 
+    @Column(name = "edu_start_date")
+    private String eduStartDate;
+
+    @Column(name = "edu_end_date")
+    private String eduEndDate;
+
+    @Column(name = "edu_start_time")
+    private String eduStartTime;
+
+    @Column(name = "edu_end_time")
+    private String eduEndTime;
+
     @Column(name = "edu_region")
     private String eduRegion;
 }

--- a/src/main/java/com/mumu/mumu/domain/Edu.java
+++ b/src/main/java/com/mumu/mumu/domain/Edu.java
@@ -71,18 +71,6 @@ public class Edu {
     @Column(name = "edu_teacher")
     private String eduTeacher;
 
-    @Column(name = "edu_start_date")
-    private String eduStartDate;
-
-    @Column(name = "edu_end_date")
-    private String eduEndDate;
-
-    @Column(name = "edu_start_time")
-    private String eduStartTime;
-
-    @Column(name = "edu_end_time")
-    private String eduEndTime;
-
     @Column(name = "edu_region")
     private String eduRegion;
 }

--- a/src/main/java/com/mumu/mumu/dto/EduDetailResponseDto.java
+++ b/src/main/java/com/mumu/mumu/dto/EduDetailResponseDto.java
@@ -1,0 +1,114 @@
+package com.mumu.mumu.dto;
+
+import com.mumu.mumu.domain.Edu;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+public class EduDetailResponseDto {
+
+    private long eduId;
+    private String eduName;
+    private String eduDate; // 요일 포함된 문자열로 포맷
+    private String eduMethod;
+    private String eduAddress;
+    private String eduSchedule; // 변경된 부분: List<String> -> String
+    private String eduTarget;
+    private String eduContent;
+    private String eduUrl;
+    private boolean bookmarked;
+
+    // 생성자
+    public EduDetailResponseDto(Edu edu) {
+        this.eduId = edu.getEduId();
+        this.eduName = edu.getEduName();
+        this.eduDate = formatEduDate(edu.getRecruitmentStartDate(), edu.getRecruitmentEndDate());
+        this.eduMethod = edu.getEduMethod();
+        this.eduAddress = formatEduAddress(edu.getEduAddress());
+        this.eduSchedule = formatEduSchedule(edu.getRecruitmentStartTime(), edu.getRecruitmentEndTime());
+        this.eduTarget = edu.getEduTarget();
+        this.eduContent = getEduContent();
+        this.eduUrl = edu.getEduUrl();
+        this.bookmarked = false;
+    }
+
+    // 날짜를 "2025.04.22(화)" 혹은 "2025.04.22(화)~2025.04.25(금)" 형식으로 반환
+    private String formatEduDate(String startDate, String endDate) {
+        if (startDate != null && !startDate.isBlank() && endDate != null && !endDate.isBlank()) {
+            return formatDateWithDayOfWeek(startDate) + "~" + formatDateWithDayOfWeek(endDate);
+        } else if (startDate != null && !startDate.isBlank()) {
+            return formatDateWithDayOfWeek(startDate);
+        } else if (endDate != null && !endDate.isBlank()) {
+            return formatDateWithDayOfWeek(endDate);
+        } else {
+            return null;
+        }
+    }
+
+    // 날짜 문자열에 요일 붙여서 반환
+    private String formatDateWithDayOfWeek(String dateStr) {
+        try {
+            LocalDate date = LocalDate.parse(dateStr); // ISO 형식: yyyy-MM-dd
+            DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy.MM.dd");
+            String formattedDate = date.format(formatter);
+            String dayOfWeek = getKoreanDayOfWeek(date);
+            return formattedDate + "(" + dayOfWeek + ")";
+        } catch (Exception e) {
+            return dateStr; // 파싱 실패 시 원본 반환
+        }
+    }
+
+    // 요일을 한글로 반환
+    private String getKoreanDayOfWeek(LocalDate date) {
+        return switch (date.getDayOfWeek()) {
+            case MONDAY -> "월";
+            case TUESDAY -> "화";
+            case WEDNESDAY -> "수";
+            case THURSDAY -> "목";
+            case FRIDAY -> "금";
+            case SATURDAY -> "토";
+            case SUNDAY -> "일";
+        };
+    }
+
+    // edu_start_time과 edu_end_time을 결합하여 edu_schedule을 "10:00~12:00" 형식으로 반환
+    private String formatEduSchedule(String startTime, String endTime) {
+        // 시간 값이 비어 있거나 형식이 잘못되었을 경우 처리
+        if (startTime == null || startTime.isBlank() || endTime == null || endTime.isBlank()) {
+            return ""; // 빈 문자열 반환
+        }
+
+        // 시간 값을 두 자릿수로 맞추어 형식 변경 (예: "14" -> "14:00")
+        String formattedStartTime = formatTime(startTime);
+        String formattedEndTime = formatTime(endTime);
+
+        return formattedStartTime + "~" + formattedEndTime;
+    }
+
+    // 시간 값을 두 자릿수로 포맷팅
+    private String formatTime(String time) {
+        if (time.length() == 1) {
+            return "0" + time + ":00"; // "14" -> "14:00"
+        } else if (time.length() == 2) {
+            return time + ":00"; // "14" -> "14:00"
+        }
+        return time; // 유효하지 않으면 그대로 반환
+    }
+
+    // 서울특별시 00구까지만 출력
+    private String formatEduAddress(String address) {
+        if (address != null && address.startsWith("서울특별시")) {
+            String[] addressParts = address.split(" ");
+            if (addressParts.length >= 2) {
+                return addressParts[0] + " " + addressParts[1]; // "서울특별시 00구" 형태
+            }
+        }
+        return address; // 서울특별시가 아닌 경우 원본 주소 반환
+    }
+}

--- a/src/main/java/com/mumu/mumu/dto/EduListResponseDto.java
+++ b/src/main/java/com/mumu/mumu/dto/EduListResponseDto.java
@@ -28,10 +28,10 @@ public class EduListResponseDto {
         this.eduId = edu.getEduId();
         this.field = edu.getField();
         this.eduName = edu.getEduName();
-        this.eduDate = formatEduDate(edu.getEduStartDate(), edu.getEduEndDate());
+        this.eduDate = formatEduDate(edu.getRecruitmentStartDate(), edu.getRecruitmentEndDate());
         this.eduMethod = edu.getEduMethod();
         this.eduAddress = formatEduAddress(edu.getEduAddress());
-        this.eduSchedule = formatEduSchedule(edu.getEduStartTime(), edu.getEduEndTime());
+        this.eduSchedule = formatEduSchedule(edu.getRecruitmentStartTime(), edu.getRecruitmentEndTime());
         this.eduTarget = edu.getEduTarget();
         this.eduUrl = edu.getEduUrl();
         this.bookmarked = false;

--- a/src/main/java/com/mumu/mumu/service/EduListService.java
+++ b/src/main/java/com/mumu/mumu/service/EduListService.java
@@ -1,9 +1,12 @@
 package com.mumu.mumu.service;
 
 import com.mumu.mumu.domain.Edu;
+import com.mumu.mumu.dto.EduListResponseDto;
 
 import java.util.List;
 
 public interface EduListService {
     List<Edu> getEduList(String region, String field, String status);
+
+    EduListResponseDto getEduById(Long eduId);
 }

--- a/src/main/java/com/mumu/mumu/service/EduListService.java
+++ b/src/main/java/com/mumu/mumu/service/EduListService.java
@@ -1,12 +1,12 @@
 package com.mumu.mumu.service;
 
 import com.mumu.mumu.domain.Edu;
-import com.mumu.mumu.dto.EduListResponseDto;
+import com.mumu.mumu.dto.EduDetailResponseDto;
 
 import java.util.List;
 
 public interface EduListService {
     List<Edu> getEduList(String region, String field, String status);
 
-    EduListResponseDto getEduById(Long eduId);
+    EduDetailResponseDto getEduById(Long eduId);
 }

--- a/src/main/java/com/mumu/mumu/service/EduListServiceImpl.java
+++ b/src/main/java/com/mumu/mumu/service/EduListServiceImpl.java
@@ -7,6 +7,8 @@ import org.springframework.data.domain.Sort;
 import org.springframework.data.jpa.domain.Specification;
 import org.springframework.stereotype.Service;
 
+import java.time.LocalDate;
+import java.util.ArrayList;
 import java.util.List;
 
 @Service
@@ -20,7 +22,7 @@ public class EduListServiceImpl implements EduListService {
 
     @Override
     public List<Edu> getEduList(String region, String field, String status) {
-        Specification<Edu> spec = Specification.where(null);  // 시작은 null
+        Specification<Edu> spec = Specification.where(null);
 
         if (region != null && !region.isBlank()) {
             spec = spec.and(EduListSpecification.hasRegion(region));
@@ -32,11 +34,31 @@ public class EduListServiceImpl implements EduListService {
             spec = spec.and(EduListSpecification.hasStatus(status));
         }
 
-        Sort sort = Sort.by(
-                Sort.Order.asc("eduStartDate"),
-                Sort.Order.asc("eduName")
+        LocalDate today = LocalDate.now();
+
+        // 미래 데이터 (오늘 이후 포함) : 날짜 오름차순 → 이름 오름차순
+        List<Edu> futureList = eduListRepository.findAll(
+                spec.and(EduListSpecification.startDateAfterOrEqual(today)),
+                Sort.by(
+                        Sort.Order.asc("recruitmentStartDate"),
+                        Sort.Order.asc("eduName")
+                )
         );
 
-        return eduListRepository.findAll(spec, sort);
+        // 과거 데이터 (오늘 이전) : 날짜 내림차순 → 이름 오름차순
+        List<Edu> pastList = eduListRepository.findAll(
+                spec.and(EduListSpecification.startDateBefore(today)),
+                Sort.by(
+                        Sort.Order.desc("recruitmentStartDate"),
+                        Sort.Order.asc("eduName")
+                )
+        );
+
+        // 미래 + 과거 합치기
+        List<Edu> result = new ArrayList<>(futureList.size() + pastList.size());
+        result.addAll(futureList);
+        result.addAll(pastList);
+
+        return result;
     }
 }

--- a/src/main/java/com/mumu/mumu/service/EduListServiceImpl.java
+++ b/src/main/java/com/mumu/mumu/service/EduListServiceImpl.java
@@ -1,6 +1,7 @@
 package com.mumu.mumu.service;
 
 import com.mumu.mumu.domain.Edu;
+import com.mumu.mumu.dto.EduListResponseDto;
 import com.mumu.mumu.repository.EduListRepository;
 import com.mumu.mumu.specification.EduListSpecification;
 import org.springframework.data.domain.Sort;
@@ -60,5 +61,12 @@ public class EduListServiceImpl implements EduListService {
         result.addAll(pastList);
 
         return result;
+    }
+
+    @Override
+    public EduListResponseDto getEduById(Long eduId) {
+        Edu edu = eduListRepository.findById(eduId)
+                .orElseThrow(() -> new IllegalArgumentException("해당 교육이 존재하지 않습니다. id=" + eduId));
+        return new EduListResponseDto(edu);
     }
 }

--- a/src/main/java/com/mumu/mumu/service/EduListServiceImpl.java
+++ b/src/main/java/com/mumu/mumu/service/EduListServiceImpl.java
@@ -1,7 +1,7 @@
 package com.mumu.mumu.service;
 
 import com.mumu.mumu.domain.Edu;
-import com.mumu.mumu.dto.EduListResponseDto;
+import com.mumu.mumu.dto.EduDetailResponseDto;
 import com.mumu.mumu.repository.EduListRepository;
 import com.mumu.mumu.specification.EduListSpecification;
 import org.springframework.data.domain.Sort;
@@ -63,10 +63,11 @@ public class EduListServiceImpl implements EduListService {
         return result;
     }
 
+    // edu_id로 단건 조회
     @Override
-    public EduListResponseDto getEduById(Long eduId) {
+    public EduDetailResponseDto getEduById(Long eduId) {
         Edu edu = eduListRepository.findById(eduId)
                 .orElseThrow(() -> new IllegalArgumentException("해당 교육이 존재하지 않습니다. id=" + eduId));
-        return new EduListResponseDto(edu);
+        return new EduDetailResponseDto(edu);
     }
 }

--- a/src/main/java/com/mumu/mumu/specification/EduListSpecification.java
+++ b/src/main/java/com/mumu/mumu/specification/EduListSpecification.java
@@ -23,12 +23,31 @@ public class EduListSpecification {
 
     public static Specification<Edu> hasStatus(String status) {
         return (root, query, cb) -> {
-            if (status == null || !status.equalsIgnoreCase("ongoing")) return null;
-            LocalDate today = LocalDate.now();
-            return cb.and(
-                    cb.lessThanOrEqualTo(root.get("eduStartDate"), today),
-                    cb.greaterThanOrEqualTo(root.get("eduEndDate"), today)
-            );
+            if (status == null || status.isBlank()) return null;
+
+            if (status.equalsIgnoreCase("모집중")) {
+                return cb.equal(root.get("recruitmentStatus"), "모집중");
+            } else if (status.equalsIgnoreCase("모집완료")) {
+                return cb.equal(root.get("recruitmentStatus"), "모집완료");
+            } else if (status.equalsIgnoreCase("모집 전")) {
+                return cb.equal(root.get("recruitmentStatus"), "모집전");
+            } else {
+                return null;
+            }
         };
+    }
+
+    // 오늘 이후(포함) 데이터 필터링
+    public static Specification<Edu> startDateAfterOrEqual(LocalDate date) {
+        return (root, query, cb) -> cb.greaterThanOrEqualTo(
+                root.get("recruitmentStartDate"), date.toString()
+        );
+    }
+
+    // 오늘 이전 데이터 필터링
+    public static Specification<Edu> startDateBefore(LocalDate date) {
+        return (root, query, cb) -> cb.lessThan(
+                root.get("recruitmentStartDate"), date.toString()
+        );
     }
 }


### PR DESCRIPTION
1. IS RELATED TO #10 

2. 변경 사항
- edu_id로 교육 상세 조회하는 기능 구현(/api/edu/{edu_id})
- 교육 리스트가 뜨는 기준이 시간순>이름순이었는데, 시간순으로 설정하니 과거 데이터부터 뜨게 됨. 그래서 현재부터 미래까지가 먼저 뜨고 그 이후에 과거가 역순으로 뜨게 수정함.