### PR TITLE
[Fix] eduAddress 속성 eduRegion으로 변경

### DIFF
--- a/src/main/java/com/mumu/mumu/specification/EduListSpecification.java
+++ b/src/main/java/com/mumu/mumu/specification/EduListSpecification.java
@@ -10,7 +10,7 @@ public class EduListSpecification {
     public static Specification<Edu> hasRegion(String region) {
         return (root, query, cb) -> {
             if (region == null || region.isBlank()) return null;
-            return cb.like(root.get("eduAddress"), "%" + region + "%");
+            return cb.like(root.get("eduRegion"), "%" + region + "%");
         };
     }
 


### PR DESCRIPTION
eduAddress 속성은 전체 주소가 담겨있는 속성이고, eduRegion 속성이 "00구"에 대한 정보만 있어서 필터링에서 사용할 속성을 eduRegion으로 변경함.