### PR TITLE
[Fix] 프론트 redirect uri 삭제

### DIFF
--- a/src/main/java/com/mumu/mumu/controller/KakaoLoginController.java
+++ b/src/main/java/com/mumu/mumu/controller/KakaoLoginController.java
@@ -34,7 +34,7 @@ public class KakaoLoginController {
 
     @GetMapping("/auth/kakao/url")
     public ResponseEntity<?> getKakaoLoginUrl() {
-        String url = "https://kauth.kakao.com/oauth/authorize?response_type=code&client_id=" + clientId + "&redirect_uri=" + redirectUri;
+        String url = "https://kauth.kakao.com/oauth/authorize?response_type=code&client_id=" + clientId;
         return ResponseEntity.ok(Map.of("url", url));
     }
 


### PR DESCRIPTION
/auth/kakao/url로 카카오 로그인 url 생성 시 프론트에서 자유롭게 설정할 수 있게 response 변경

변경 전
"url": "https://kauth.kakao.com/oauth/authorize?response_type=code&client_id=df2~&redirect_uri=http://localhost:3000/kakao/callback"

변경 후
"url": "https://kauth.kakao.com/oauth/authorize?response_type=code&client_id=df2~"