### PR TITLE
[Fix] 카카오 로그인 리디렉션 처리 및 콜백 엔드포인트 구현

### DIFF
--- a/src/main/java/com/mumu/mumu/controller/KakaoLoginController.java
+++ b/src/main/java/com/mumu/mumu/controller/KakaoLoginController.java
@@ -10,6 +10,8 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 import java.io.IOException;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
 import java.util.Map;
 
 @Slf4j
@@ -34,8 +36,22 @@ public class KakaoLoginController {
 
     @GetMapping("/auth/kakao/url")
     public ResponseEntity<?> getKakaoLoginUrl() {
-        String url = "https://kauth.kakao.com/oauth/authorize?response_type=code&client_id=" + clientId;
+        String encodedRedirectUri = URLEncoder.encode(redirectUri, StandardCharsets.UTF_8);
+        String url = "https://kauth.kakao.com/oauth/authorize"
+                + "?response_type=code"
+                + "&client_id=" + clientId
+                + "&redirect_uri=" + encodedRedirectUri;
+
         return ResponseEntity.ok(Map.of("url", url));
+    }
+
+    @GetMapping("/auth/kakao/redirect")
+    public ResponseEntity<?> redirectToFrontend(@RequestParam("code") String code) {
+        // 프론트에 인가 코드를 전달하는 리디렉션
+        String frontendUrl = "https://mumu-for-youth.github.io/MUMU_Frontend//#/kakao/callback?code=" + code;
+        return ResponseEntity.status(HttpStatus.FOUND)
+                .header("Location", frontendUrl)
+                .build();
     }
 
     @PostMapping("/auth/kakao/callback")


### PR DESCRIPTION
1. 변경 사항
해시라우터와 브라우저라우터가 있는데 github를 통한 배포를 해둔 상태기 때문에 해시라우터만 사용 가능. 그러나 해시 라우터는 #을 포함한 url을 쓰기 때문에 카카오개발자콘솔에 redirect uri로 등록 불가. 그래서 가져온 해결 방법
	1.	사용자 → 로그인 버튼 클릭
	2.	프론트 → 백엔드에서 https://kauth.kakao.com/oauth/authorize?... URL 생성
	•	redirect_uri=https://your-backend.com/auth/kakao/redirect
	3.	카카오 로그인 완료 후 백엔드가 code를 받고
	4.	백엔드가 다시 사용자 브라우저를 /#/kakao/callback?code=… 로 리디렉션
	5.	프론트가 HashRouter 기반으로 코드 처리

2. 스크린샷 (선택)
![image](https://github.com/user-attachments/assets/3d4711a9-21d5-47fd-ad57-c6459ca4533f)
