### PR TITLE
[Fix] 액세스 토큰 발급 시 redirect uri 설정

### DIFF
--- a/src/main/java/com/mumu/mumu/controller/KakaoLoginController.java
+++ b/src/main/java/com/mumu/mumu/controller/KakaoLoginController.java
@@ -49,7 +49,7 @@ public class KakaoLoginController {
     public ResponseEntity<?> redirectToFrontend(@RequestParam("code") String code) {
         // 프론트에 인가 코드를 전달하는 리디렉션
 //        String frontendUrl = "https://mumu-for-youth.github.io/MUMU_Frontend//#/kakao/callback?code=" + code;
-        String frontendUrl = "http://localhost:3000/#kakao/callback?code=" + code;
+        String frontendUrl = "http://localhost:3000/#/kakao/callback?code=" + code;
         return ResponseEntity.status(HttpStatus.FOUND)
                 .header("Location", frontendUrl)
                 .build();

--- a/src/main/java/com/mumu/mumu/service/KakaoService.java
+++ b/src/main/java/com/mumu/mumu/service/KakaoService.java
@@ -38,12 +38,14 @@ public class KakaoService {
 
     // 카카오로부터 액세스 토큰을 얻는 메서드
     public KakaoTokenResponseDto getTokenFromKakao(String code) {
+        String redirectUri = "http://localhost:3000/MUMU_Frontend";
         KakaoTokenResponseDto kakaoTokenResponseDto = WebClient.create(KAUTH_TOKEN_URL_HOST).post()
                 .uri(uriBuilder -> uriBuilder
                         .scheme("https")
                         .path("/oauth/token")
                         .queryParam("grant_type", "authorization_code")
                         .queryParam("client_id", clientId)
+                        .queryParam("redirect_uri", redirectUri)
                         .queryParam("code", code)
                         .build(true))
                 .header(HttpHeaders.CONTENT_TYPE, HttpHeaderValues.APPLICATION_X_WWW_FORM_URLENCODED.toString())


### PR DESCRIPTION
카카오 서버에서 redirect uri를 필수로 요청해서 이를 수정함.